### PR TITLE
feat: v0.1.0-preview6, supports --output for fetch-token

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	AlibabaCloudIdaasCliVersion = "0.1.0-preview5"
+	AlibabaCloudIdaasCliVersion = "0.1.0-preview6"
 
 	DefaultAudienceAlibabaCloudIdaas = "alibaba-cloud-idaas-v2"
 


### PR DESCRIPTION
Subcommand `fetch-token` supports flag `--output` (or `-o`), outputs token to assigned filename